### PR TITLE
Support for Laravel 5.4.x 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # laravel-u2f
 [![Code Climate](https://codeclimate.com/github/certly/laravel-u2f/badges/gpa.svg)](https://codeclimate.com/github/certly/laravel-u2f) [![Build Status](https://travis-ci.org/certly/laravel-u2f.svg?branch=master)](https://travis-ci.org/certly/laravel-u2f)
 
-Integrate FIDO U2F into Laravel 5.x applications. You'll need to be accessing your application from an [App ID compliant](https://developers.yubico.com/U2F/App_ID.html) domain; `localhost` support is finicky.
+Integrate FIDO U2F into Laravel 5.4.x applications. You'll need to be accessing your application from an [App ID compliant](https://developers.yubico.com/U2F/App_ID.html) domain; `localhost` support is finicky.
 
 ## Install
 ``` bash
 composer require certly/laravel-u2f
 ```
 
-In `config/app.php`, add the provider `Certly\U2f\LaravelU2fServiceProvider::class` to the providers array and `'U2f' => Certly\U2f\U2fServiceFacade::class` to the aliases array.
+In `config/app.php`, add the provider `Certly\U2f\U2fServiceProvider::class,` to the providers array and `'U2f' => Certly\U2f\U2fServiceProvider::class,` to the aliases array.
 
 
 ### Publishing
@@ -38,7 +38,7 @@ In the `app/Http/Kernel.php` file, add the following to `$routeMiddleware`. This
 ``` php
 protected $routeMiddleware = [
     // ...
-    'u2f' => Certly\U2f\Http\Middleware\U2f::class,
+    'u2f' => \App\U2f\Http\Middleware\U2f::class,
 ];
 ```
 

--- a/src/Http/Controllers/U2fController.php
+++ b/src/Http/Controllers/U2fController.php
@@ -88,7 +88,7 @@ class U2fController extends Controller
     {
         $user = $request->user();
         try {
-            $key = $this->u2f->doAuthenticate($user, session()->put('u2f.authenticationData'), json_decode($request->input('authentication')));
+            $key = $this->u2f->doAuthenticate($user, session()->get('u2f.authenticationData'), json_decode($request->input('authentication')));
             event('u2f.authentication', ['u2fKey' => $key, 'user' => $user]);
             $request->session()->forget('u2f.authenticationData');
             return $this->redirectAfterSuccessAuth();

--- a/src/Http/Controllers/U2fController.php
+++ b/src/Http/Controllers/U2fController.php
@@ -6,6 +6,14 @@ use Exception;
 use Illuminate\Config\Repository as Config;
 use Illuminate\Http\Request;
 
+/**
+ * Laravel U2F - Integrate FIDO U2F into Laravel 5.4.x applications
+ *
+ * @package  laravel-u2f
+ * @author   LAHAXE Arnaud
+ * @author   romanornr (support for Laravel 5.4)
+ */
+
 class U2fController extends Controller
 {
     /**

--- a/src/Http/Controllers/U2fController.php
+++ b/src/Http/Controllers/U2fController.php
@@ -93,7 +93,7 @@ class U2fController extends Controller
             session()->forget('u2f.authenticationData');
             return $this->redirectAfterSuccessAuth();
         } catch (Exception $e) {
-            //Session::flash('error', $e->getMessage());
+            $request->session()->flash('error', $e->getMessage());
             return redirect()->route('u2f.auth.data');
         }
     }

--- a/src/Http/Middleware/U2f.php
+++ b/src/Http/Middleware/U2f.php
@@ -10,11 +10,7 @@ use Illuminate\Config\Repository as Config;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 
 /**
- * Class U2f.
- *
- *
- *
- * @author  LAHAXE Arnaud
+ * Class U2f
  */
 class U2f
 {
@@ -27,13 +23,12 @@ class U2f
      * @var Config
      */
     protected $config;
-
     public function __construct(LaravelU2f $u2f, Config $config)
     {
         $this->u2f = $u2f;
         $this->config = $config;
     }
-
+    
     /**
      * Handle an incoming request.
      *
@@ -47,18 +42,16 @@ class U2f
         if (!$this->config->get('u2f.enable')) {
             return $next($request);
         }
-
         if (!$this->u2f->check()) {
             if (Auth::guest()) {
                 throw new HttpException(401, 'You need to log in before an u2f authentication');
             }
-            if (U2fKey::where('user_id', '=', Auth::user()->id)->count() === 0 && $this->config->get('u2f.byPassUserWithoutKey')) {
+            if (U2fKey::where('user_id', '=', $request->user()->id)->count() === 0 && $this->config->get('u2f.byPassUserWithoutKey')) {
                 return $next($request);
             }
-
-            return redirect()->guest('u2f/auth');
+            Auth::logout();
+            abort(403, 'Unauthorized U2F action.');
         }
-
         return $next($request);
     }
 }

--- a/src/Http/Middleware/U2f.php
+++ b/src/Http/Middleware/U2f.php
@@ -10,6 +10,14 @@ use Illuminate\Config\Repository as Config;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 
 /**
+ * Laravel U2F - Integrate FIDO U2F into Laravel 5.4.x applications
+ *
+ * @package  laravel-u2f
+ * @author   LAHAXE Arnaud
+ * @author   romanornr (support for Laravel 5.4)
+ */
+
+/**
  * Class U2f
  */
 class U2f

--- a/src/U2f.php
+++ b/src/U2f.php
@@ -112,7 +112,7 @@ class U2f
         $U2fKey->counter = $reg->counter;
         $U2fKey->save();
 
-        $this->session->set($this->config->get('u2f.sessionU2fName'), true);
+        $this->session->put($this->config->get('u2f.sessionU2fName'), true);
 
         return $U2fKey;
     }

--- a/src/U2fServiceProvider.php
+++ b/src/U2fServiceProvider.php
@@ -56,7 +56,7 @@ class U2fServiceProvider extends ServiceProvider
         $this->publishes([(__DIR__.'/../config/u2f.php') => config_path('u2f.php')], 'config');
 
         $this->publishes([
-            __DIR__.'/../resources/js' => base_path('/resources/js/u2f'),
+            __DIR__.'/../resources/js' => base_path('/public/js/u2f'),
         ], 'public');
 
         $this->publishes([

--- a/views/authentication.blade.php
+++ b/views/authentication.blade.php
@@ -1,11 +1,8 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
-        "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html>
+<!DOCTYPE html>
+<html lang="en">
 <head>
-    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-    <meta http-equiv="Content-Language" content="fr" />
-    <script src="{!! secure_asset('vendor/u2f/u2f.js') !!}"></script>
-    <script src="{!! secure_asset('vendor/u2f/app.js') !!}"></script>
+    <script type="text/javascript" src="{!! asset('js/u2f/u2f.js') !!}"></script>
+    <script type="text/javascript" src="{!! asset('js/u2f/app.js') !!}"></script>
     <link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css" rel="stylesheet">
 </head>
 <body>

--- a/views/authentication.blade.php
+++ b/views/authentication.blade.php
@@ -33,13 +33,16 @@
                     <br>
                     {{ trans('u2f::messages.noButtonAdvise') }}
                 </p>
+                {{ Form::open(array('action' => 'U2fController@auth', 'id' => 'form')) }}
+                {{ Form::hidden('authentication', '', ['id' => 'authentication']) }}
+                {{ Form::close() }}
             </div>
         </div>
     </div>
 </div>
 
 
-{!! Form::open(array('route' => 'u2f.auth', 'id' => 'form')) !!}
+{!! Form::open(array('action' => array('U2fController@auth', 'id' => 'form'))) !!}
 {!! Form::hidden('authentication', '', ['id' => 'authentication']) !!}
 {!! Form::close() !!}
 

--- a/views/register.blade.php
+++ b/views/register.blade.php
@@ -34,9 +34,9 @@
                     <br>
                     {{ trans('u2f::messages.noButtonAdvise') }}
                 </p>
-				{!! Form::open(array('action' => 'U2fController@register', 'id' => 'form')) !!}
-    			{!! Form::hidden('register', '', ['id' => 'register']) !!}
-				{!! Form::close() !!}
+                        {{ Form::open(array('action' => 'U2fController@register', 'id' => 'form')) }}
+                        {{ Form::hidden('register', '', ['id' => 'register']) }}
+                        {{ Form::close() }}
             </div>
         </div>
     </div>

--- a/views/register.blade.php
+++ b/views/register.blade.php
@@ -34,21 +34,21 @@
                     <br>
                     {{ trans('u2f::messages.noButtonAdvise') }}
                 </p>
+				{!! Form::open(array('action' => 'U2fController@register', 'id' => 'form')) !!}
+    			{!! Form::hidden('register', '', ['id' => 'register']) !!}
+				{!! Form::close() !!}
             </div>
         </div>
     </div>
 </div>
 
-
-
-{!! Form::open(array('route' => 'u2f.register', 'id' => 'form')) !!}
+{!! Form::open(array('action' => array('U2fController@register', 'id' => 'form'))) !!}
     {!! Form::hidden('register', '', ['id' => 'register']) !!}
 {!! Form::close() !!}
 
 <script type="text/javascript">
     var sigs = {!! json_encode($currentKeys) !!};
     var req = {!! json_encode($registerData) !!};
-
     var errors = {
         1: "{{ trans('u2f::errors.other_error') }}",
         2: "{{ trans('u2f::errors.bad_request') }}",

--- a/views/register.blade.php
+++ b/views/register.blade.php
@@ -1,15 +1,11 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
-        "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html>
+<!DOCTYPE html>
+<html lang="en">
 <head>
-    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-    <meta http-equiv="Content-Language" content="fr" />
-    <script src="{!! secure_asset('vendor/u2f/u2f.js') !!}"></script>
-    <script src="{!! secure_asset('vendor/u2f/app.js') !!}"></script>
+    <script type="text/javascript" src="{!! asset('js/u2f/u2f.js') !!}"></script>
+    <script type="text/javascript" src="{!! asset('js/u2f/app.js') !!}"></script>
     <link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css" rel="stylesheet">
 </head>
 <body>
-
 
 
 <div class="container" style="margin-top:30px">


### PR DESCRIPTION
Lots of things changed from Laravel 5.0 to 5.4.

The old implementation doesn't work on Laravel 5.4.
I rewrote the controller.

Things like Session::set is now changed to session()->put()
Also the Events::fire is now events()
from Redirect:: into route()->
The instructions needed to change too. 

I did't make use of the Auth:: helper. It can be done with $user = $request->user();
Since people tend to make a Models folder in Laravel.

With Request, it allows for a flexible implementation.

I also removed not required else statements.
After a return statements, the else is useless anyways.  